### PR TITLE
fix: clean up activeElements after resize

### DIFF
--- a/src/trigger.js
+++ b/src/trigger.js
@@ -49,6 +49,8 @@ function eventListeners() {
         activeElements.forEach((element) => {
           ob.unobserve(element.el);
         });
+        // Clean up activeElements
+        activeElements = []
       },
     });
   });


### PR DESCRIPTION
https://github.com/triggerjs/trigger/blob/3831e957a54c4765defd40664adf31610aadecd3/src/trigger.js#L44-L54

resize 事件里的 before hook 会不断的往 activeElements 添加重复元素，直到滚动事件发生
