### PR TITLE
Remove unnecessary default value for parameter `hook`

### DIFF
--- a/src/bind.js
+++ b/src/bind.js
@@ -1,6 +1,6 @@
 import { getPrefix } from "./prefix";
 
-export default function (observer, hook = {}) {
+export default function (observer, hook) {
   // Before Hook
   hook && typeof hook.before === "function" && hook.before();
 


### PR DESCRIPTION
`hook = {}` is not necessary since there is a null/undefined check in the code.

```js
hook && typeof hook.before === "function" && hook.before();
```