### PR TITLE
refactoring: converted some mutable variables to constant, and more

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,6 +4,6 @@
  * @returns {number} The caculated length.
  */
 export function decimalsLength(number: number): number {
-  if (Math.floor(number.valueOf()) === number.valueOf()) return 0;
+  if (Math.floor(number) === number) return 0;
   return number.toString().split('.')[1].length || 0;
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -85,13 +85,11 @@ export function parseValues(elements: TgElement[]) {
       return;
     }
 
-    // edge = cover by default
-    let percentage = (scrolled - top + clientHeight) / (clientHeight + height);
-
-    // edge = inset
-    if (edge === 'inset') {
-      percentage = (scrolled - top) / (height - clientHeight);
-    }
+    // edge is 'cover' by default
+    const percentage =
+      edge === 'inset'
+        ? (scrolled - top) / (height - clientHeight)
+        : (scrolled - top + clientHeight) / (clientHeight + height);
 
     let value: string | number;
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -8,11 +8,8 @@ import { TgElement } from './type';
 // This function will be called in observe stage, caching those values into an object for ease of use in scroll event.
 export function parseAttributes(element: HTMLElement): TgElement {
   const follow: HTMLElement = extractValues(element, `${getPrefix()}follow`);
-  let actualElement = element;
 
-  if (follow !== null) {
-    actualElement = follow;
-  }
+  const actualElement = follow || element;
 
   const style = getComputedStyle(actualElement);
   const top = Number(style.getPropertyValue('--tg-top'));

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -59,8 +59,8 @@ export function parseAttributes(element: HTMLElement): TgElement {
 
 // Calculation happens here, this function is called when scroll event happens. So keep this as light as possible.
 export function parseValues(elements: TgElement[]) {
-  let scrolled = document.documentElement.scrollTop;
-  let clientHeight = document.documentElement.clientHeight;
+  const scrolled = document.documentElement.scrollTop;
+  const clientHeight = document.documentElement.clientHeight;
 
   elements.forEach((element) => {
     const {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -93,7 +93,7 @@ export function parseValues(elements: TgElement[]) {
 
     let value: string | number;
 
-    let mappingValue = (
+    const mappingValue = (
       from +
       Math.floor((segments + 1) * percentage) * increment * multiplier
     ).toFixed(decimals);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -63,7 +63,7 @@ export function parseValues(elements: TgElement[]) {
   let clientHeight = document.documentElement.clientHeight;
 
   elements.forEach((element) => {
-    let {
+    const {
       el,
       top,
       height,


### PR DESCRIPTION
I converted some mutable variables to constant because I think it's cleaner.

Also, in the `helpers.ts`, there is no need to call `valueOf` explicitly because based on the function signature, parameter "number" is a `number`, not an object created with `new Number()`. please take a look at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf#examples