### PR TITLE
doc: fix jsDelivr CDN URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Read this document in other languages: [English](README.md), [繁體中文](READ
     ```
    - jsDelivr CDN:
     ```html
-    <script src="//jsdelivr.com/package/npm/@triggerjs/trigger" defer></script>
+    <script src="//cdn.jsdelivr.net/npm/@triggerjs/trigger" defer></script>
     ```
 
 2. Add `tg-name` to the DOM element that you want to monitor. The value of `tg-name` is the name of the CSS variable that binds to the element.

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -27,7 +27,7 @@
     ```
    - jsDelivr CDN:
     ```html
-    <script src="//jsdelivr.com/package/npm/@triggerjs/trigger" defer></script>
+    <script src="//cdn.jsdelivr.net/npm/@triggerjs/trigger" defer></script>
     ```
 
 2. 为对应的 DOM 元素加上 `tg-name` 属性，设定值等于接收数值的 CSS 变量名。

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -27,7 +27,7 @@
     ```
    - jsDelivr CDN:
     ```html
-    <script src="//jsdelivr.com/package/npm/@triggerjs/trigger" defer></script>
+    <script src="//cdn.jsdelivr.net/npm/@triggerjs/trigger" defer></script>
     ```
 
 2. 為對應的 DOM 元素加上 `tg-name` 屬性，設定值等於接收數值的 CSS 變數名。


### PR DESCRIPTION
The current jsDelivr CDN URL is pointing to the full package instead of the entry resource. So it can't be used as the script source.